### PR TITLE
Fix Password page

### DIFF
--- a/pages/password.tsx
+++ b/pages/password.tsx
@@ -89,6 +89,9 @@ const _: NextPage = () => {
             value={passwordType}
             exclusive
             onChange={(_, newType) => {
+              if (newType === null) {
+                return;
+              }
               setPasswordType(newType as typeof types[number]);
               setPasswordsDebounced({ type: newType, length });
             }}


### PR DESCRIPTION
I fixed an error that occurred when the same password type was clicked.

I want to modify it to generate the password again, but it doesn't work. Do you have any ideas?
The following code would have resulted in a `TypeError` (Unknown type: null).

```typescript
          <ToggleButtonGroup
            value={passwordType}
            exclusive
            onChange={(_, newType) => {
              if (newType === null) {
                setPasswords(generate({ type: passwordType, length }))
                return;
              }
              setPasswordType(newType as typeof types[number]);
              setPasswordsDebounced({ type: newType, length });
            }}
          >
```